### PR TITLE
Checking Tokens Funded without making a transaction

### DIFF
--- a/contracts/EthLend.sol
+++ b/contracts/EthLend.sol
@@ -132,7 +132,7 @@ contract Ledger {
 
           for(uint i=0; i<totalLrCount; ++i){
                LendingRequest lr = LendingRequest(lrs[i]);
-               if(lr.getState() == LendingRequest.State.WaitingForPayback){
+               if(lr.getCurrentState() == LendingRequest.State.WaitingForPayback){
                     out++;
                }
           }
@@ -142,7 +142,7 @@ contract Ledger {
 
      function getLrFunded(uint index) constant returns (address){          
           LendingRequest lr = LendingRequest(lrs[index]);
-          if(lr.getState() == LendingRequest.State.WaitingForPayback){
+          if(lr.getCurrentState() == LendingRequest.State.WaitingForPayback){
                return lrs[index];
           } else {
                return 0;
@@ -255,7 +255,6 @@ contract LendingRequest {
      /* Constants Methods: */
      function isEns() constant returns(bool){ return (currentType==Type.EnsCollateral); }
      function isRep() constant returns(bool){ return (currentType==Type.RepCollateral); }
-     function getState() constant returns(State){ return currentState; }
      function getLender() constant returns(address){ return lender; }     
      function getBorrower() constant returns(address){ return borrower; }
      function getWantedWei() constant returns(uint){ return wanted_wei; }

--- a/contracts/EthLend.sol
+++ b/contracts/EthLend.sol
@@ -337,7 +337,6 @@ contract LendingRequest {
                // we are ready to search someone 
                // to give us the money
                return State.WaitingForLender;
-               return;
             }
           }else{
             return currentState;


### PR DESCRIPTION
Made currentState variable private and added getCurrentState() function to access currentState
Removed checkTokens and getCurrentState() returning WaitingForLender state only when tokens are transferred
Removed getState() function from LendingRequest contract and referencing getCurrentState() function wherever required in Ledger contract instead of getState()